### PR TITLE
fix: Safari focus 수정 및 코드 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ build/
 
 # OMC (oh-my-claudecode)
 .omc/
+.DS_Store

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ const GuideDiv = styled.div`
     transform: translate(-50%, -50%);
   }
 `;
-const App: React.VFC = () => {
+const App: React.FC = () => {
   const isPcW = useMediaQuery({
     query: '(min-width : 1280px)',
   });

--- a/src/api/client.tsx
+++ b/src/api/client.tsx
@@ -4,4 +4,12 @@ const client = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_ENDPOINT_URL,
 });
 
+client.interceptors.request.use((config) => {
+  const token = sessionStorage.getItem('accessToken');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export default client;

--- a/src/block/DirectoryBlock.tsx
+++ b/src/block/DirectoryBlock.tsx
@@ -122,7 +122,7 @@ const DirectoryBlock: React.FC<DirectoryProps> = ({ setVisible, messageFiles, wi
               {messageFiles.map((file: SimpleMessageData, index: number) => (
                 <Col lg="auto" key={index}>
                   <div className="file-page">
-                    <button className="file" onClick={onMessage} data-id={file.messageID}>
+                    <button className="file" onMouseDown={(e) => e.currentTarget.focus()} onClick={onMessage} data-id={file.messageID}>
                       <img src={fileimg} alt="file" />
                       <div className="file-name">{file.senderNickname.length >= 5 ? `${file.senderNickname.slice(0, 4)}...` : file.senderNickname}</div>
                     </button>

--- a/src/block/HeaderWatchBlock.tsx
+++ b/src/block/HeaderWatchBlock.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const HeaderWatchBlock: React.VFC = () => {
+const HeaderWatchBlock: React.FC = () => {
   const [nowTime, setNowTime] = useState('');
 
   useEffect(() => {

--- a/src/block/RegisterBlock.tsx
+++ b/src/block/RegisterBlock.tsx
@@ -122,7 +122,7 @@ interface FormValues {
   userPasswordConfirm: string;
 }
 
-const RegisterBlock: React.VFC = () => {
+const RegisterBlock: React.FC = () => {
   const navigate = useNavigate();
   const [user, setUser] = useState<userProps>({
     userClusterName: '',

--- a/src/common/DraggableWindow.tsx
+++ b/src/common/DraggableWindow.tsx
@@ -110,16 +110,12 @@ const DraggableWindow: React.FC<DraggableWindowProps> = ({
       };
 
       refDiv.addEventListener('mousemove', moveDrag);
-      document.addEventListener('mousemove', moveDrag); // 빠르게 마우스를 이동하면 refDiv의 영역에서 나가서 이벤트가 발생을 안함.
-      document.addEventListener(
-        'mouseup',
-        () => {
-          document.removeEventListener('mousemove', moveDrag);
-          refDiv.removeEventListener('mousemove', moveDrag);
-        },
-        { once: true },
-      );
-      refDiv.addEventListener('mouseup', () => refDiv.removeEventListener('mousemove', moveDrag));
+      document.addEventListener('mousemove', moveDrag);
+      const cleanup = () => {
+        document.removeEventListener('mousemove', moveDrag);
+        refDiv.removeEventListener('mousemove', moveDrag);
+      };
+      document.addEventListener('mouseup', cleanup, { once: true });
     }
   }, []);
 

--- a/src/module/LoginContext.tsx
+++ b/src/module/LoginContext.tsx
@@ -11,7 +11,7 @@ export const LoginContext = createContext<LoginContextProps>({
 });
 
 const LoginContextProvider: React.FC<React.ReactNode> = ({ children }) => {
-  const [login, setLogin] = useState(false);
+  const [login, setLogin] = useState(() => sessionStorage.getItem('accessToken') !== null);
 
   const value = useMemo(() => ({ login, setLogin }), [login, setLogin]);
   return <LoginContext.Provider value={value}>{children}</LoginContext.Provider>;

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -1,7 +1,7 @@
 import MessageWriteBlock from '../block/MessageWriteBlock';
 import CautionWindow from '../common/CautionWindow';
 
-const WritePage: React.VFC = () => {
+const WritePage: React.FC = () => {
   return (
     <div>
       <div style={{ width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>


### PR DESCRIPTION
## Summary

- **Safari focus 수정** (Closes #37): `<button>` 클릭 시 Safari에서 focus가 부여되지 않아 파일 하이라이트가 동작하지 않던 문제를 `onMouseDown`에서 명시적 `focus()` 호출로 해결
- **React.VFC → FC 마이그레이션**: React 18에서 deprecated된 `VoidFunctionComponent`를 `FunctionComponent`로 통일
- **axios interceptor**: 매 요청마다 수동 설정 대신 request interceptor로 Bearer 토큰 자동 첨부
- **로그인 상태 유지**: 페이지 새로고침 시 sessionStorage 기반으로 로그인 상태 복원
- **DraggableWindow cleanup**: 드래그 이벤트 리스너 해제 로직을 단일 cleanup 함수로 통합
- **chore**: `.DS_Store`를 `.gitignore`에 추가

## Test plan

- [ ] Safari에서 파일 클릭 시 하이라이트 색상 변경 확인
- [ ] Chrome/Firefox에서 기존 동작 유지 확인
- [ ] 페이지 새로고침 후 로그인 상태 유지 확인
- [ ] 윈도우 드래그 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)